### PR TITLE
fix: add limit to 200 GitHub elements

### DIFF
--- a/components/github/HistoryCleaner.vue
+++ b/components/github/HistoryCleaner.vue
@@ -14,6 +14,22 @@
             >GitHub repository</NuxtLink
           >.
         </p>
+        <div class="mt-4 rounded-md bg-yellow-50 p-4">
+          <div class="flex">
+            <div class="flex-shrink-0">
+              <ExclamationTriangleIcon class="h-5 w-5 text-yellow-400" aria-hidden="true" />
+            </div>
+            <div class="ml-3">
+              <h3 class="text-sm font-medium text-yellow-800">Limited to {{ limitNumberElements }} elements</h3>
+              <div class="mt-2 text-sm text-yellow-700">
+                <p>
+                  Currently, the tool is limited to {{ limitNumberElements }} elements. If you have more than
+                  {{ limitNumberElements }} elements to delete, just run the tool again.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
 
       <div class="lg:col-start-2 lg:col-end-4">
@@ -259,8 +275,11 @@ import {
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
 } from "@heroicons/vue/24/outline";
+import { limitNumberElements as limit } from "@/server/dao/github.dao";
 
 const config = useRuntimeConfig();
+
+const limitNumberElements = limit;
 
 const disabled = ref({
   submit: true,
@@ -385,8 +404,8 @@ async function confirm(): Promise<void> {
 
         default:
           alert(`An error occurred, please try again later.
-          Error status: [${error.response.status}].
-          Error message: [${error.response._data.message}].`);
+          ${error.response.status ? `Error status: [${error.response.status}].` : ""}
+          ${error.response._data.message ? `Error message: [${error.response._data.message}].` : ""}`);
           break;
       }
     },

--- a/server/dao/github.dao.ts
+++ b/server/dao/github.dao.ts
@@ -55,7 +55,7 @@ export async function getWorkflowRuns(
   token: string,
   page: number = 1
 ): Promise<GitHubWorkflowRunApiResponse> {
-  return await api(`/repos/${account}/${repository}/actions/runs`, {
+  return (await api(`/repos/${account}/${repository}/actions/runs`, {
     method: "GET",
     headers: {
       Authorization: `Bearer ${token}`,
@@ -80,7 +80,7 @@ export async function getWorkflowRuns(
         });
       }
     },
-  });
+  })) as GitHubWorkflowRunApiResponse;
 }
 
 /**

--- a/server/dao/github.dao.ts
+++ b/server/dao/github.dao.ts
@@ -8,6 +8,12 @@ const api = getApiConfiguration();
 const maximumPerPage = 100;
 
 /**
+ * Limit to 200 elements to avoid FUNCTION_INVOCATION_TIMEOUT error from Vercel.
+ * @see https://vercel.com/docs/errors/FUNCTION_INVOCATION_TIMEOUT
+ */
+export const limitNumberElements = 200;
+
+/**
  * Retrieves all workflow runs for a given account and repository.
  *
  * @param account - The account name.
@@ -21,7 +27,9 @@ export async function getAllWorkflowRuns(account: string, repository: string, to
   let total = response.total_count - response.workflow_runs.length;
   let page = 2;
 
-  while (total > 0) {
+  let continueExecution = true;
+
+  while (total > 0 && continueExecution) {
     logger.debug(`Retrieving page [${page}] of workflow runs for [${account}/${repository}] repository`);
 
     const newResponse: GitHubWorkflowRunApiResponse = await getWorkflowRuns(account, repository, token, page);
@@ -30,6 +38,11 @@ export async function getAllWorkflowRuns(account: string, repository: string, to
     response.workflow_runs.push(...newResponse.workflow_runs);
 
     logger.debug(`Added [${newResponse.workflow_runs.length}] workflow runs to the workflow runs array`);
+
+    if (response.workflow_runs.length >= limitNumberElements) {
+      logger.debug(`Stopping execution. Maximum workflow runs reached: [${response.workflow_runs.length}]`);
+      continueExecution = false;
+    }
 
     page++;
   }

--- a/server/tests/dao/github.dao.nuxt.test.ts
+++ b/server/tests/dao/github.dao.nuxt.test.ts
@@ -76,8 +76,8 @@ describe("GitHub DAO", async () => {
       ...workflowRunsApiResponse.workflow_runs,
     ];
 
-    expect(result).toEqual(expected);
-    expect(result.length).toEqual(300);
+    expect(result).toEqual(expected.slice(0, 200));
+    expect(result.length).toEqual(200);
   });
 
   test("should throw an error when cannot retrieve workflow runs", async () => {


### PR DESCRIPTION
This pull request adds a type assertion to the getWorkflowRuns function in order to improve type safety and prevent potential errors. Additionally, it fixes a bug by adding a limit of 200 GitHub elements to avoid a FUNCTION_INVOCATION_TIMEOUT error from Vercel.