### PR TITLE
perf(analytics): add Matomo plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@nuxt/image": "^1.7.0",
         "@prisma/client": "^5.17.0",
         "matter-js": "^0.19.0",
+        "vue-matomo": "^4.2.0",
         "vue-writer": "^1.2.0",
         "zod": "^3.23.8"
       },
@@ -20043,6 +20044,16 @@
       "integrity": "sha512-RutnB7X8c5hjq39NceArgXg28WZtZpGc3+J16ljMiYnFhKvd8hITxSWQSQ5bvldxMDU6gG5mkxl1MTQLXckVSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vue-matomo": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/vue-matomo/-/vue-matomo-4.2.0.tgz",
+      "integrity": "sha512-m5hCw7LH3wPDcERaF4sp/ojR9sEx7Rl8TpOyH/4jjQxMF2DuY/q5pO+i9o5Dx+BXLSa9+IQ0qhAbWYRyESQXmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
     },
     "node_modules/vue-router": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@nuxt/image": "^1.7.0",
     "@prisma/client": "^5.17.0",
     "matter-js": "^0.19.0",
+    "vue-matomo": "^4.2.0",
     "vue-writer": "^1.2.0",
     "zod": "^3.23.8"
   },

--- a/plugins/matomo.client.ts
+++ b/plugins/matomo.client.ts
@@ -1,0 +1,92 @@
+// @ts-ignore
+import VueMatomo from "vue-matomo";
+
+export default defineNuxtPlugin((nuxtApp) => {
+  if (!import.meta.env.DEV && location.hostname !== "localhost" && location.hostname !== "127.0.0.1") {
+    nuxtApp.vueApp.use(VueMatomo, {
+      host: "https://analytics.monitoring.anthonypillot.com",
+
+      siteId: 1,
+
+      // Enables automatically registering pageviews on the router
+      router: nuxtApp.$router,
+
+      // Enables link tracking on regular links. Note that this won't
+      // work for routing links (ie. internal Vue router links)
+      // Default: true
+      enableLinkTracking: true,
+
+      // Require consent before sending tracking information to matomo
+      // Default: false
+      requireConsent: false,
+
+      // Whether to track the initial page view
+      // Default: true
+      trackInitialView: true,
+
+      // Run Matomo without cookies
+      // Default: false
+      disableCookies: false,
+
+      // Require consent before creating matomo session cookie
+      // Default: false
+      requireCookieConsent: false,
+
+      // Enable the heartbeat timer (https://developer.matomo.org/guides/tracking-javascript-guide#accurately-measure-the-time-spent-on-each-page)
+      // Default: false
+      enableHeartBeatTimer: false,
+
+      // Set the heartbeat timer interval
+      // Default: 15
+      heartBeatTimerInterval: 15,
+
+      // Whether or not to log debug information
+      // Default: false
+      debug: false,
+
+      // UserID passed to Matomo (see https://developer.matomo.org/guides/tracking-javascript-guide#user-id)
+      // Default: undefined
+      userId: undefined,
+
+      // Share the tracking cookie across subdomains (see https://developer.matomo.org/guides/tracking-javascript-guide#measuring-domains-andor-sub-domains)
+      // Default: undefined, example '*.example.com'
+      cookieDomain: undefined,
+
+      // Tell Matomo the website domain so that clicks on these domains are not tracked as 'Outlinks'
+      // Default: undefined, example: '*.example.com'
+      domains: undefined,
+
+      // A list of pre-initialization actions that run before matomo is loaded
+      // Default: []
+      // Example: [
+      //   ['API_method_name', parameter_list],
+      //   ['setCustomVariable','1','VisitorType','Member'],
+      //   ['appendToTrackingUrl', 'new_visit=1'],
+      //   etc.
+      // ]
+      preInitActions: [],
+
+      // A function to determine whether to track an interaction as a site search
+      // instead of as a page view. If not a function, all interactions will be
+      // tracked as page views. Receives the new route as an argument, and
+      // returns either an object of keyword, category (optional) and resultsCount
+      // (optional) to track as a site search, or a falsey value to track as a page
+      // view.
+      // Default: false, i.e. track all interactions as page views
+      // Example: (to) => {
+      //   if (to.query.q && to.name === 'search') {
+      //     return { keyword: to.query.q, category: to.params.category }
+      //   } else {
+      //    return null
+      //   }
+      // }
+      trackSiteSearch: false,
+
+      // Set this to include crossorigin attribute on the matomo script import
+      // Default: undefined, possible values : 'anonymous', 'use-credentials'
+      crossOrigin: undefined,
+    });
+  } else {
+    console.debug("Matomo is disabled in development mode");
+  }
+});


### PR DESCRIPTION
This pull request adds the Matomo plugin to the project. The plugin allows for tracking analytics using Matomo, including pageviews, link tracking, and site searches. The plugin is configured with the host URL, site ID, and various tracking options.