### PR TITLE
fix(task-holdem): reset selected card on restart and improve layout for revealed results

### DIFF
--- a/components/task-holdem/PokerTable.vue
+++ b/components/task-holdem/PokerTable.vue
@@ -26,11 +26,13 @@
           }}
         </button>
       </div>
-      <div v-else-if="game.status === 'revealed'" class="text-center">
-        <p class="text-white text-lg">Result</p>
-        <p class="text-white"><span class="text-gray-200">Average</span>: {{ getAverage() }}</p>
+      <div v-else-if="game.status === 'revealed'" class="flex flex-col gap-4 text-center">
+        <div>
+          <p class="text-white text-lg">Result</p>
+          <p class="text-white"><span class="text-gray-200">Average</span>: {{ getAverage() }}</p>
+        </div>
         <button
-          class="text-white bg-indigo-800 border border-white min-w-24 rounded-md px-2 py-1 mt-4 hover:bg-white hover:text-black"
+          class="text-white bg-indigo-950 border border-white rounded-sm px-4 py-2 cursor-pointer hover:bg-white hover:text-black"
           @click="emit('restart')"
           data-testid="restart-button"
         >

--- a/pages/tools/task-holdem/application.client.vue
+++ b/pages/tools/task-holdem/application.client.vue
@@ -49,7 +49,7 @@
         :game="room.game"
         @revealing="setGameStatus('revealing')"
         @revealed="setGameStatus('revealed')"
-        @restart="setGameStatus('playing')"
+        @restart="setGameStatus('restarting')"
       />
       <section class="flex flex-col gap-2">
         <p class="text-white">Select a card:</p>
@@ -197,6 +197,14 @@ socket.on("room-update", (roomFromServer: Room) => {
   room.value = roomFromServer;
 });
 
+socket.on("room-restart", (roomFromServer: Room) => {
+  cards.value.forEach((card) => {
+    card.isSelected = false;
+  });
+
+  room.value = roomFromServer;
+});
+
 function createUser(userToCreate: User | null) {
   if (userToCreate) {
     user.value = userToCreate;
@@ -296,16 +304,13 @@ function selectCard(selectedCard: Card): void {
 
 function setGameStatus(status: GameStatus): void {
   room.value.game.status = status;
-  socket.emit("room-update", room.value);
+
+  if (status === "restarting") {
+    socket.emit("room-restart", room.value);
+  } else {
+    socket.emit("room-update", room.value);
+  }
 }
-
-socket.on("room-restart", (roomFromServer: Room) => {
-  cards.value.forEach((card) => {
-    card.isSelected = false;
-  });
-
-  room.value = roomFromServer;
-});
 
 //#region Chat
 

--- a/server/services/task-holdem.service.ts
+++ b/server/services/task-holdem.service.ts
@@ -3,48 +3,52 @@ import * as dao from "@/server/dao/task-holdem.dao";
 import { prefixLog, type Room } from "@/types/task-holdem.type";
 
 export function getOrCreateRoom(id: string): Promise<Room> {
+  logger.debug(`${prefixLog} Room created or fetched`);
   return dao.getOrCreateRoom(id);
 }
 
 export function updateRoom(id: string, roomToUpdate: Room): Promise<Room> {
+  logger.debug(`${prefixLog} Room updated`);
   return dao.updateRoom(id, roomToUpdate);
 }
 
-export function restartRoom(roomId: string, room: Room): Promise<Room> {
+export function restartRoom(id: string, room: Room): Promise<Room> {
+  logger.debug(`${prefixLog} Room restarted`);
+
   room.game.status = "playing";
   room.users.forEach((user) => {
     user.selectedCard = null;
   });
 
-  return updateRoom(roomId, room);
+  return updateRoom(id, room);
 }
 
-export function getUserBySessionId(roomId: string, sessionId: string): Promise<User | null> {
-  return dao.getUserBySessionId(roomId, sessionId);
+export function getUserBySessionId(id: string, sessionId: string): Promise<User | null> {
+  return dao.getUserBySessionId(id, sessionId);
 }
 
-export async function createUser(roomId: string, sessionId: string, userToCreate: User): Promise<Room> {
-  const room: Room = await getOrCreateRoom(roomId);
+export async function createUser(id: string, sessionId: string, userToCreate: User): Promise<Room> {
+  const room: Room = await getOrCreateRoom(id);
   if (!room.users.find((user) => user.id === userToCreate.id)) {
     logger.debug(`${prefixLog} User to create: [${userToCreate.name}]`);
     userToCreate.sessionId = sessionId;
     room.users.push(userToCreate);
   }
 
-  return updateRoom(roomId, room);
+  return updateRoom(id, room);
 }
 
-export async function removeUser(roomId: string, userToRemove: User): Promise<Room> {
-  const room: Room = await getOrCreateRoom(roomId);
+export async function removeUser(id: string, userToRemove: User): Promise<Room> {
+  const room: Room = await getOrCreateRoom(id);
   room.users = room.users.filter((user) => user.id !== userToRemove.id);
 
   logger.debug(`${prefixLog} User removed: [${userToRemove.name}]`);
 
-  return updateRoom(roomId, room);
+  return updateRoom(id, room);
 }
 
-export async function removeUserBySessionId(roomId: string, sessionId: string): Promise<Room | null> {
-  const room: Room | null = await dao.getRoom(roomId);
+export async function removeUserBySessionId(id: string, sessionId: string): Promise<Room | null> {
+  const room: Room | null = await dao.getRoom(id);
   if (room) {
     const userToRemove = room.users.find((user) => user.sessionId === sessionId);
 
@@ -55,7 +59,7 @@ export async function removeUserBySessionId(roomId: string, sessionId: string): 
 
       logger.debug(`${prefixLog} User disconnected: [${userToRemove.name}]`);
 
-      return updateRoom(roomId, room);
+      return updateRoom(id, room);
     } else {
       return null;
     }

--- a/types/task-holdem.type.ts
+++ b/types/task-holdem.type.ts
@@ -12,7 +12,7 @@ export const application = {
 
 export const prefixLog = `[WEBSOCKET - ${application.name}]`;
 
-export type GameStatus = "playing" | "revealing" | "revealed";
+export type GameStatus = "playing" | "revealing" | "revealed" | "restarting";
 
 export type Room = {
   users: User[];


### PR DESCRIPTION
The changes ensure that the selected card resets when the restart button is clicked, addressing the issue of the card remaining selected. Additionally, the layout for revealed game results has been improved for better user experience.

Fixes #52.