### PR TITLE
fix(ui): keep button text readable during press-and-hold

### DIFF
--- a/app/components/base/Header.vue
+++ b/app/components/base/Header.vue
@@ -26,7 +26,7 @@
             label="Tools"
             variant="ghost"
             trailing-icon="i-heroicons-chevron-down"
-            class="text-sm font-semibold text-white rounded-md px-2 py-1 hover:bg-white hover:text-black"
+            class="text-sm font-semibold text-white rounded-md px-2 py-1 hover:bg-white hover:text-black active:bg-white active:text-black"
           />
 
           <template #content="{ close }">
@@ -106,7 +106,7 @@
                   label="Tools"
                   variant="ghost"
                   trailing-icon="i-heroicons-chevron-down"
-                  class="-mx-3 text-base font-semibold text-default hover:bg-muted"
+                  class="-mx-3 text-base font-semibold text-default hover:bg-muted active:bg-muted"
                 />
 
                 <template #content="{ close }">

--- a/app/components/it-facts/ItFactsHero.vue
+++ b/app/components/it-facts/ItFactsHero.vue
@@ -26,7 +26,7 @@
             color="neutral"
             trailing-icon="i-heroicons-arrow-right"
             size="sm"
-            class="ring-white hover:text-white hover:bg-neutral-900 dark:hover:text-neutral-900 dark:hover:bg-white"
+            class="ring-white hover:text-white hover:bg-neutral-900 active:text-white active:bg-neutral-900 dark:hover:text-neutral-900 dark:hover:bg-white dark:active:text-neutral-900 dark:active:bg-white"
             data-testid="it-facts-launch"
             />
           </div>

--- a/app/pages/tools/task-holdem/index.vue
+++ b/app/pages/tools/task-holdem/index.vue
@@ -23,7 +23,7 @@
             color="neutral"
             trailing-icon="i-heroicons-arrow-right"
             size="sm"
-            class="ring-white hover:text-white hover:bg-neutral-900 dark:hover:text-neutral-900 dark:hover:bg-white"
+            class="ring-white hover:text-white hover:bg-neutral-900 active:text-white active:bg-neutral-900 dark:hover:text-neutral-900 dark:hover:bg-white dark:active:text-neutral-900 dark:active:bg-white"
             data-testid="task-holdem-launch"
             />
           </div>


### PR DESCRIPTION
## Summary

Fixes #90

The Nuxt UI `UButton` theme applies an `active:bg-*` background on press-and-hold, but the custom classes on the four affected buttons only override the `hover:` state. The resulting active background and text color combination loses contrast:

- Desktop **Tools** trigger: white text on `bg-primary/10` (faint indigo)
- Mobile **Tools** trigger: default text on `bg-muted` was OK, but now explicit
- **Launch Task Hold'em** / **Launch IT Facts**: white text on near-white `bg-elevated` in light mode

## Fix

Mirror the existing `hover:` overrides as `active:` overrides on the four affected buttons:

- `app/components/base/Header.vue:29` (desktop Tools trigger)
- `app/components/base/Header.vue:109` (mobile Tools trigger)
- `app/pages/tools/task-holdem/index.vue:26` (Launch Task Hold'em)
- `app/components/it-facts/ItFactsHero.vue:29` (Launch IT Facts)

The press-and-hold state is now visually identical to the hover state, which is already readable.

## Notes

- Originally diagnosed as a `data-[state=open]` issue (issue #90 title) — turned out to be the `:active` (mouse-pressed) state. The fix is a no-op for the popover open state.
- The launch buttons were also flagged during investigation as having a `bg-default` fill that didn't match the surrounding dark section, but the user opted to keep the filled default and only fix the active-state readability.