### PR TITLE
feat: add Plausible analytics

### DIFF
--- a/.github/workflows/build-and-push-release.yaml
+++ b/.github/workflows/build-and-push-release.yaml
@@ -38,19 +38,19 @@ jobs:
     needs: [extract, push]
     strategy:
       matrix:
-        environment: [production, pre-production]
-        shortcut: [prod, prep]
-        exclude:
+        include:
           - environment: production
-            shortcut: prep
-          - environment: pre-production
+            namespace: os-prod
             shortcut: prod
+          - environment: pre-production
+            namespace: os-prep
+            shortcut: prep
     uses: anthonypillot/actions/.github/workflows/kubernetes-deployment.yaml@v1
     with:
       registry_url: ghcr.io
       registry_username: ${{ github.repository_owner }}
       environment: ${{ matrix.environment }}
-      namespace_name: os
+      namespace_name: ${{ matrix.namespace }}
       deployment_name: os-${{ matrix.shortcut }}
       image_name: os
       image_tag: ${{ needs.extract.outputs.result }}

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -42,7 +42,7 @@ jobs:
       registry_url: ghcr.io
       registry_username: ${{ github.repository_owner }}
       environment: pre-production
-      namespace_name: os
+      namespace_name: os-prep
       deployment_name: os-prep
       image_name: os
       image_tag: ${{ needs.extract.outputs.result }}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -44,6 +44,12 @@ export default defineNuxtConfig({
     },
   },
 
+  plausible: {
+    apiHost: "https://plausible.monitoring.anthonypillot.com",
+    ignoredHostnames: ["localhost", "127.0.0.1"],
+    proxy: true,
+  },
+
   vite: {
     optimizeDeps: {
       include: ["@vue/devtools-core", "@vue/devtools-kit", "gsap", "matter-js", "vue-matomo"],
@@ -57,7 +63,7 @@ export default defineNuxtConfig({
     "/tools/task-holdem": { swr: true },
   },
 
-  modules: ["@nuxt/ui", "@nuxt/eslint", "@nuxt/image", "@nuxt/test-utils/module"],
+  modules: ["@nuxt/ui", "@nuxt/eslint", "@nuxt/image", "@nuxt/test-utils/module", "@nuxtjs/plausible"],
 
   devtools: { enabled: true },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@nuxt/image": "^2.0.0",
         "@nuxt/test-utils": "^4.0.3",
         "@nuxt/ui": "^4.10.0",
+        "@nuxtjs/plausible": "^3.0.2",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/auto-instrumentations-node": "^0.76.0",
         "@prisma/client": "^6.19.3",
@@ -3501,6 +3502,18 @@
         "pathe": "^2.0.3",
         "pkg-types": "^2.3.1",
         "semver": "^7.8.1"
+      }
+    },
+    "node_modules/@nuxtjs/plausible": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/plausible/-/plausible-3.0.2.tgz",
+      "integrity": "sha512-6z01a7XbggSmI4CTWCkDDmLHQNm7wob2dx1QnvpIoo+YEV19298+GsuvlBclXVxXSk7op8r8qJpw25xKo8mzQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@nuxt/kit": "^4.3.1",
+        "@plausible-analytics/tracker": "^0.4.4",
+        "defu": "^6.1.4",
+        "ufo": "^1.6.3"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -7012,6 +7025,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@plausible-analytics/tracker": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@plausible-analytics/tracker/-/tracker-0.4.5.tgz",
+      "integrity": "sha512-6BfAGejXY+YA3Cw6LYT2Zpn4hTxDtPQAawFsYUsQCOg78wIS5C4deAGXTfJffa5VleMWITv5lpJ/EYuQBl1tPA==",
+      "license": "MIT"
     },
     "node_modules/@playwright/test": {
       "version": "1.61.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@nuxt/image": "^2.0.0",
     "@nuxt/test-utils": "^4.0.3",
     "@nuxt/ui": "^4.10.0",
+    "@nuxtjs/plausible": "^3.0.2",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/auto-instrumentations-node": "^0.76.0",
     "@prisma/client": "^6.19.3",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,12 @@ import { defineVitestConfig } from "@nuxt/test-utils/config";
  * @see https://nuxt.com/docs/getting-started/testing
  */
 export default defineVitestConfig({
+  resolve: {
+    alias: {
+      // The tracker package exposes no main or exports entry for Vitest to resolve.
+      "@plausible-analytics/tracker": "@plausible-analytics/tracker/plausible.js",
+    },
+  },
   test: {
     environment: "nuxt",
     include: ["server/**/*.{test,spec}.?(c|m)[jt]s?(x)"],


### PR DESCRIPTION
## Summary

- add self-hosted Plausible analytics alongside Matomo
- proxy Plausible events through the Nuxt server to reduce ad blocking
- fix PR deployments to target the `os-prep` namespace
- map release deployments to the correct `os-prep` and `os-prod` namespaces
- keep Nuxt server tests compatible with the Plausible tracker package

## Testing

- `npm ci`
- `npm run lint` (passes with 3 pre-existing warnings)
- `npm test -- --run` (12 tests passed)
- `npm run build`
- validated both GitHub Actions workflow files as YAML